### PR TITLE
Update logging

### DIFF
--- a/src/logging.jl
+++ b/src/logging.jl
@@ -22,3 +22,8 @@ function round_from_tol(n::Real, tol::Real, rshift::Int)
     # Round a number n to the same number of digits as the tolerance (+ shift on the right)
     return round(n, digits = (-1) * get_exponent_sciform(tol) + rshift)
 end
+
+# Functions to round / reformat timing records
+function tidy_timing(time::Real)
+    return round(time, digits = 3)
+end


### PR DESCRIPTION
This PR makes a few changes to the logging so that MacroEnergySolvers plays a bit better with MacroEnergy, without changing any of the functionality.

1. Adds an argument to `benders` to determine whether logs should be formatted according to MacroEnergySolvers.jl logs or the calling package (i.e. MacroEnergy.jl)

2. Makes all timing logs print with three decimal places. this may still be too much.

3. Defines the log string for iterations once to make it easier to maintain.