### PR TITLE
Added haskey check on slacks

### DIFF
--- a/src/benders/algorithms.jl
+++ b/src/benders/algorithms.jl
@@ -93,6 +93,8 @@ function benders(planning_problem::Model,subproblems::Union{Vector{Dict{Any, Any
 		binary_variables = planning_variables_ref[is_binary.(planning_variables_ref)];
 		unset_integer.(integer_variables)
 		unset_binary.(binary_variables)
+		set_lower_bound.(binary_variables, 0)
+		set_upper_bound.(binary_variables, 1)
 		integer_routine_flag = true;
 	end
 

--- a/src/benders/subproblems.jl
+++ b/src/benders/subproblems.jl
@@ -30,6 +30,12 @@ function add_slacks_to_subproblem!(subproblem::Model)
     ### Slack variables are added to the subproblems and fixed to zero. 
     ### We will then allow slack variables to be non-zero to generate feasibility cuts when a subproblem is infeasible.
 
+    if haskey(subproblem, :slack_max)
+        @warn "Variable slack_max already exists in the model. Skipping addition of slack variables"
+        @warn "If user is rerunning a model and has updated any constraints, new constraints added since last solve will NOT include the slack. Proceed with caution."
+        return nothing
+    end
+
     eq_cons =  all_constraints(subproblem,AffExpr,MOI.EqualTo{Float64})
     less_ineq_cons = all_constraints(subproblem,AffExpr,MOI.LessThan{Float64})
     greater_ineq_cons = all_constraints(subproblem,AffExpr,MOI.GreaterThan{Float64})


### PR DESCRIPTION
Added a check in the `add_slacks_to_subproblem!(subproblem::Model)` function to check if slacks have been added. This addresses #15 to support resolving an existing model with the `benders` call (such as for external hot-starting of a model). If a user calls `benders` on a model that has already been solved, it will not error when `ExpectFeasibleSubproblems=false`. 